### PR TITLE
fix table naming to support escaped naming

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -99,7 +99,7 @@ abstract class Entity
     protected static function forceNamingScheme($name, $namingScheme)
     {
         $words = explode('_', preg_replace(
-            '/([^A-Z_])([A-Z])/',
+            '/([a-z0-9])([A-Z])/',
             '$1_$2',
             preg_replace_callback('/([A-Z][A-Z]+)([A-Z][a-z])/', function ($d) {
                 return '_' . $d[1] . '_' . $d[2];

--- a/tests/Entity/TableNameTest.php
+++ b/tests/Entity/TableNameTest.php
@@ -129,6 +129,7 @@ class TableNameTest extends TestCase
             [Psr0_StudlyCaps::class, '%name[-2]%', 'Psr0'],
             [Psr0_StudlyCaps::class, '%name[-2*]%', 'Psr0_Studly_Caps'],
             [Psr0_StudlyCaps::class, '%name[0]%_%name[-1]%', 'ORM_Studly_Caps'],
+            [Psr0_StudlyCaps::class, '"%name[0]%"."%name[-1]%"', '"ORM"."Studly_Caps"'],
         ];
     }
 


### PR DESCRIPTION
Some databases preserve words and to use table with this name you maybe need to enclose it with special characters. Postgres supports different schemes and they need to be prepended to table name.