### PR TITLE
Use static instead of self in return type hinting

### DIFF
--- a/src/Dbal/Dbal.php
+++ b/src/Dbal/Dbal.php
@@ -44,7 +44,7 @@ abstract class Dbal
      *
      * @param string $option
      * @param mixed  $value
-     * @return self
+     * @return static
      */
     public function setOption($option, $value)
     {

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -175,7 +175,7 @@ abstract class Entity implements \Serializable
 
     /**
      * @param EM $entityManager
-     * @return self
+     * @return static
      */
     public function setEntityManager(EM $entityManager)
     {

--- a/src/EntityFetcher.php
+++ b/src/EntityFetcher.php
@@ -68,7 +68,7 @@ class EntityFetcher extends QueryBuilder
         $this->classMapping['byAlias']['t0']   = $class;
     }
 
-    /** @return self
+    /** @return static
      * @internal
      */
     public function columns(array $columns = null)
@@ -76,7 +76,7 @@ class EntityFetcher extends QueryBuilder
         return $this;
     }
 
-    /** @return self
+    /** @return static
      * @internal
      */
     public function column($column, $args = [], $alias = '')

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -171,7 +171,7 @@ class EntityManager
      * Define $this EntityManager as the default EntityManager for $nameSpace
      *
      * @param $nameSpace
-     * @return self
+     * @return static
      */
     public function defineForNamespace($nameSpace)
     {
@@ -183,7 +183,7 @@ class EntityManager
      * Define $this EntityManager as the default EntityManager for subClasses of $class
      *
      * @param $class
-     * @return self
+     * @return static
      */
     public function defineForParent($class)
     {
@@ -196,7 +196,7 @@ class EntityManager
      *
      * @param string $option One of OPT_* constants
      * @param mixed $value
-     * @return self
+     * @return static
      */
     public function setOption($option, $value)
     {

--- a/src/Namer.php
+++ b/src/Namer.php
@@ -55,7 +55,7 @@ class Namer
      *
      * @param string $option
      * @param mixed  $value
-     * @return self
+     * @return static
      */
     public function setOption($option, $value)
     {

--- a/src/QueryBuilder/ParenthesisInterface.php
+++ b/src/QueryBuilder/ParenthesisInterface.php
@@ -33,7 +33,7 @@ interface ParenthesisInterface
      * @param string       $column   Column or expression with placeholders
      * @param string|array $operator Operator, value or array of values
      * @param string       $value    Value (required when used with operator)
-     * @return self
+     * @return static
      */
     public function where($column, $operator = '', $value = '');
 
@@ -59,7 +59,7 @@ interface ParenthesisInterface
      * @param string       $column   Column or expression with placeholders
      * @param string|array $operator Operator, value or array of values
      * @param string       $value    Value (required when used with operator)
-     * @return self
+     * @return static
      */
     public function andWhere($column, $operator = '', $value = '');
 
@@ -85,7 +85,7 @@ interface ParenthesisInterface
      * @param string       $column   Column or expression with placeholders
      * @param string|array $operator Operator, value or array of values
      * @param string       $value    Value (required when used with operator)
-     * @return self
+     * @return static
      */
     public function orWhere($column, $operator = '', $value = '');
 
@@ -93,21 +93,21 @@ interface ParenthesisInterface
      * Alias for andParenthesis
      *
      * @see ParenthesisInterface::andWhere()
-     * @return ParenthesisInterface
+     * @return static
      */
     public function parenthesis();
 
     /**
      * Add a parenthesis with AND
      *
-     * @return ParenthesisInterface
+     * @return static
      */
     public function andParenthesis();
 
     /**
      * Add a parenthesis with OR
      *
-     * @return ParenthesisInterface
+     * @return static
      */
     public function orParenthesis();
 

--- a/src/QueryBuilder/QueryBuilder.php
+++ b/src/QueryBuilder/QueryBuilder.php
@@ -203,8 +203,10 @@ class QueryBuilder extends Parenthesis implements QueryBuilderInterface
         return $this;
     }
 
-    /** @internal
-     * @return self */
+    /**
+     * @internal
+     * @return static
+     */
     public function close()
     {
         return $this;

--- a/src/QueryBuilder/QueryBuilderInterface.php
+++ b/src/QueryBuilder/QueryBuilderInterface.php
@@ -17,7 +17,7 @@ interface QueryBuilderInterface extends ParenthesisInterface
      * Set $columns
      *
      * @param $columns
-     * @return self
+     * @return static
      */
     public function columns(array $columns = null);
 
@@ -44,7 +44,7 @@ interface QueryBuilderInterface extends ParenthesisInterface
      * @param string|boolean $expression Expression, single column name or boolean to create an empty join
      * @param string         $alias      Alias for the table
      * @param array          $args       Arguments for expression
-     * @return self|ParenthesisInterface
+     * @return static|ParenthesisInterface
      */
     public function join($tableName, $expression = '', $alias = '', $args = []);
 
@@ -59,7 +59,7 @@ interface QueryBuilderInterface extends ParenthesisInterface
      * @param string|boolean $expression Expression, single column name or boolean to create an empty join
      * @param string         $alias      Alias for the table
      * @param array          $args       Arguments for expression
-     * @return self|ParenthesisInterface
+     * @return static|ParenthesisInterface
      */
     public function leftJoin($tableName, $expression = '', $alias = '', $args = []);
 
@@ -74,7 +74,7 @@ interface QueryBuilderInterface extends ParenthesisInterface
      * @param string|boolean $expression Expression, single column name or boolean to create an empty join
      * @param string         $alias      Alias for the table
      * @param array          $args       Arguments for expression
-     * @return self|ParenthesisInterface
+     * @return static|ParenthesisInterface
      */
     public function rightJoin($tableName, $expression = '', $alias = '', $args = []);
 
@@ -90,7 +90,7 @@ interface QueryBuilderInterface extends ParenthesisInterface
      * @param string|boolean $expression Expression, single column name or boolean to create an empty join
      * @param string         $alias      Alias for the table
      * @param array          $args       Arguments for expression
-     * @return self|ParenthesisInterface
+     * @return static|ParenthesisInterface
      */
     public function fullJoin($tableName, $expression = '', $alias = '', $args = []);
 
@@ -101,7 +101,7 @@ interface QueryBuilderInterface extends ParenthesisInterface
      *
      * @param string $column Column or expression for groups
      * @param array  $args   Arguments for expression
-     * @return self
+     * @return static
      */
     public function groupBy($column, $args = []);
 
@@ -113,7 +113,7 @@ interface QueryBuilderInterface extends ParenthesisInterface
      * @param string $column    Column or expression for order
      * @param string $direction Direction (default: `ASC`)
      * @param array  $args      Arguments for expression
-     * @return self
+     * @return static
      */
     public function orderBy($column, $direction = self::DIRECTION_ASCENDING, $args = []);
 
@@ -123,7 +123,7 @@ interface QueryBuilderInterface extends ParenthesisInterface
      * Limits the amount of rows fetched from database.
      *
      * @param int $limit The limit to set
-     * @return self
+     * @return static
      */
     public function limit($limit);
 
@@ -133,7 +133,7 @@ interface QueryBuilderInterface extends ParenthesisInterface
      * Changes the offset (only with limit) where fetching starts in the query.
      *
      * @param int $offset The offset to set
-     * @return self
+     * @return static
      */
     public function offset($offset);
 
@@ -143,7 +143,7 @@ interface QueryBuilderInterface extends ParenthesisInterface
      * Add query modifiers such as SQL_CALC_FOUND_ROWS or DISTINCT.
      *
      * @param string $modifier
-     * @return self
+     * @return static
      */
     public function modifier($modifier);
 


### PR DESCRIPTION
Fixes #50. The static keyword uses late static binding to resolve the
actual class it refers to, eg the class implementing an interface instead
of the interface itself. This way static code analysis (as used in IDEs)
will properly resolve class names.