### PR TITLE
fix: use strict comparison in toArray recursion guard

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -643,7 +643,7 @@ abstract class Entity implements Serializable
 
     protected static function toArrayPreventRecursion(Entity $relatedObject, array $parents)
     {
-        if (in_array($relatedObject, $parents)) {
+        if (in_array($relatedObject, $parents, true)) {
             try {
                 $key = implode('-', $relatedObject->getPrimaryKey());
             } catch (IncompletePrimaryKey $e) {

--- a/src/Relation/ParentChildren.php
+++ b/src/Relation/ParentChildren.php
@@ -39,7 +39,7 @@ class ParentChildren extends OneToMany
     /**
      * Set all children and return an array containing the root elements
      *
-     * This method expects you to pass all elements of a branch. Keep in mind that that the array you
+     * This method expects you to pass all elements of a branch. Keep in mind that the array you
      * are getting is not necessarily from the same parent if you are not passing all elements of a branch.
      *
      * Example of this issue:

--- a/tests/Entity/ToArrayTest.php
+++ b/tests/Entity/ToArrayTest.php
@@ -160,6 +160,30 @@ class ToArrayTest extends TestCase
     }
 
     /** @test */
+    public function recursionDetectionWorksAlsoWithMocksOnParentChildRelations()
+    {
+        $parent = $this->ormCreateMockedEntity(Category::class, ['id' => 1, 'name' => 'Science']);
+        $child = $this->ormCreateMockedEntity(Category::class, ['id' => 2, 'name' => 'Fiction', 'parentId' => 1]);
+        $this->ormAddResult(Category::class, $parent, $child);
+        
+        $categories = Category::query()->all();
+        self::assertCount(2, $categories);
+        
+        $tree = Category::getRelation('children')->buildTree(...$categories);
+        self::assertCount(1, $tree);
+        
+        self::assertSame([
+            'id' => 1,
+            'name' => 'Science',
+            'children' => [[
+                'id' => 2,
+                'name' => 'Fiction',
+                'parentId' => 1,
+            ]]
+        ], $tree[0]->toArray());
+    }
+
+    /** @test */
     public function returnsArraysOfRelatedObjects()
     {
         $entity = $this->ormCreateMockedEntity(Article::class, ['id' => 42, 'text' => 'Lorem ipsum dolor sit amet...']);


### PR DESCRIPTION
toArrayPreventRecursion() compared related objects against the parent chain with loose ==, which recurses through the whole object graph. On PHP 7 this triggers a "Nesting level too deep - recursive dependency" fatal for entities with circular relations. Identity is what the guard actually means, so compare with in_array(..., true).

Add a test reproducing the fatal on PHP 7.4.