### PR TITLE
ci: add phpstan static analysis step to CI workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,6 +27,9 @@ jobs:
 
       - name: Install dependencies
         run: composer install --no-interaction --ansi
+        
+      - name: Execute Static Analysis
+        run: vendor/bin/phpstan analyse -c phpstan.neon --no-progress
 
       - name: Execute tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/
+/.vendor-*
 _site/
 /composer.lock
 /docs/.jekyll-cache

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
     "mockery/mockery": "^1.1",
     "phpunit/phpunit": "*",
     "tflori/phpunit-printer": "*",
-    "squizlabs/php_codesniffer": "^3.5"
+    "squizlabs/php_codesniffer": "^3.5",
+    "phpstan/phpstan": "*",
+    "phpstan/phpstan-mockery": "*"
   },
   "suggest": {
     "mockery/mockery": "^1.1"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ parameters:
     paths:
         - src
     level: 5
+    reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         -
             identifier: method.notFound

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,11 @@
+includes:
+    - vendor/phpstan/phpstan-mockery/extension.neon
+
+parameters:
+    paths:
+        - src
+    level: 5
+    ignoreErrors:
+        -
+            identifier: method.notFound
+            path: src/Testing

--- a/src/BulkInsert.php
+++ b/src/BulkInsert.php
@@ -16,7 +16,7 @@ class BulkInsert
     /** @var int */
     protected $limit;
 
-    /** @var callable */
+    /** @var ?callable */
     protected $onSync;
 
     /** @var bool */

--- a/src/DbConfig.php
+++ b/src/DbConfig.php
@@ -86,8 +86,9 @@ class DbConfig
                 $this->port = $port ?: '3306';
                 isset($this->attributes[PDO::ATTR_EMULATE_PREPARES])
                     || $this->attributes[PDO::ATTR_EMULATE_PREPARES] = false;
-                isset($this->attributes[PDO::MYSQL_ATTR_INIT_COMMAND])
-                    || $this->attributes[PDO::MYSQL_ATTR_INIT_COMMAND] = "SET sql_mode ='ANSI_QUOTES', NAMES utf8";
+                $attr = PHP_VERSION_ID >= 80400 ? PDO\Mysql::ATTR_INIT_COMMAND : PDO::MYSQL_ATTR_INIT_COMMAND;
+                isset($this->attributes[$attr])
+                    || $this->attributes[$attr] = "SET sql_mode ='ANSI_QUOTES', NAMES utf8";
                 break;
 
             case 'pgsql':

--- a/src/DbConfig.php
+++ b/src/DbConfig.php
@@ -86,6 +86,7 @@ class DbConfig
                 $this->port = $port ?: '3306';
                 isset($this->attributes[PDO::ATTR_EMULATE_PREPARES])
                     || $this->attributes[PDO::ATTR_EMULATE_PREPARES] = false;
+                // @phpstan-ignore-next-line unknown.class
                 $attr = PHP_VERSION_ID >= 80400 ? PDO\Mysql::ATTR_INIT_COMMAND : PDO::MYSQL_ATTR_INIT_COMMAND;
                 isset($this->attributes[$attr])
                     || $this->attributes[$attr] = "SET sql_mode ='ANSI_QUOTES', NAMES utf8";

--- a/src/Dbal/Column.php
+++ b/src/Dbal/Column.php
@@ -10,10 +10,10 @@ use ORM\Dbal\Error\NotValid;
  * @package ORM\Dbal
  * @author  Thomas Flori <thflori@gmail.com>
  *
- * @property string name
- * @property Type   type
- * @property mixed  default
- * @property bool   nullable
+ * @property string $name
+ * @property Type   $type
+ * @property mixed  $default
+ * @property bool   $nullable
  */
 class Column
 {
@@ -36,7 +36,7 @@ class Column
      * Get the registered type for $columnDefinition
      *
      * @param array $columnDefinition
-     * @return string
+     * @return ?string
      */
     protected static function getRegisteredType(array $columnDefinition)
     {
@@ -55,7 +55,7 @@ class Column
     /** @var Dbal */
     protected $dbal;
 
-    /** @var TypeInterface */
+    /** @var ?TypeInterface */
     protected $type;
 
     /** @var bool */

--- a/src/Dbal/Column.php
+++ b/src/Dbal/Column.php
@@ -11,7 +11,7 @@ use ORM\Dbal\Error\NotValid;
  * @author  Thomas Flori <thflori@gmail.com>
  *
  * @property string $name
- * @property Type   $type
+ * @property ?Type $type
  * @property mixed  $default
  * @property bool   $nullable
  */

--- a/src/Dbal/Dbal.php
+++ b/src/Dbal/Dbal.php
@@ -433,7 +433,7 @@ abstract class Dbal
      * Extract content from parenthesis in $type
      *
      * @param string $type
-     * @return string
+     * @return ?string
      */
     protected function extractParenthesis($type)
     {

--- a/src/Dbal/Error.php
+++ b/src/Dbal/Error.php
@@ -44,4 +44,15 @@ class Error extends Exception
 
         parent::__construct($namer->substitute($this->message, $params), 0, $previous);
     }
+
+    public function getErrorCode(): string
+    {
+        return $this->errorCode;
+    }
+
+    public function getError(): ?Error
+    {
+        $prev = $this->getPrevious();
+        return $prev instanceof Error ? $prev : null;
+    }
 }

--- a/src/Dbal/Error.php
+++ b/src/Dbal/Error.php
@@ -24,17 +24,21 @@ class Error extends Exception
     /**
      * Error constructor
      *
-     * @param array  $params
-     * @param null   $code
-     * @param null   $message
-     * @param ?Error $previous
+     * @param array   $params
+     * @param ?string    $code
+     * @param ?string $message
+     * @param ?Error  $previous
      */
-    public function __construct(array $params = [], $code = null, $message = null, ?Error $previous = null)
-    {
-        $this->message = $message ?: $this->message;
-        $this->code    = $code ?: static::ERROR_CODE;
+    public function __construct(
+        array $params = [],
+        ?string $code = null,
+        ?string $message = null,
+        ?Error $previous = null
+    ) {
+        $this->message   = $message ?: $this->message;
+        $this->errorCode = $code ?: static::ERROR_CODE;
 
-        $params['code'] = $this->code;
+        $params['code'] = $this->errorCode;
 
         $namer = EntityManager::getInstance()->getNamer();
 

--- a/src/Dbal/Escaping.php
+++ b/src/Dbal/Escaping.php
@@ -20,7 +20,7 @@ trait Escaping
     /**
      * Returns $identifier quoted for use in a sql statement
      *
-     * @param string $identifier Identifier to quote
+     * @param string|Expression $identifier Identifier to quote
      * @return string
      */
     public function escapeIdentifier($identifier)

--- a/src/Dbal/Mysql.php
+++ b/src/Dbal/Mysql.php
@@ -91,7 +91,7 @@ class Mysql extends Dbal
         )->fetchAll(PDO::FETCH_ASSOC);
 
         /** @var Entity $entity */
-        foreach (array_values($entities) as $key => $entity) {
+        foreach ($entities as $key => $entity) {
             $entity->setOriginalData($rows[$key]);
             $entity->reset();
             $this->entityManager->map($entity, true);

--- a/src/Dbal/Table.php
+++ b/src/Dbal/Table.php
@@ -55,10 +55,10 @@ class Table extends ArrayObject
      * Get the Column object for $col
      *
      * @param string $col
-     * @return Column
+     * @return Column|null
      */
-    public function getColumn($col)
+    public function getColumn(string $col): ?Column
     {
-        return isset($this->columns[$col]) ? $this->columns[$col] : null;
+        return $this->columns[$col] ?? null;
     }
 }

--- a/src/Dbal/Type.php
+++ b/src/Dbal/Type.php
@@ -30,6 +30,7 @@ abstract class Type implements TypeInterface
      */
     public static function factory(Dbal $dbal, array $columnDefinition)
     {
+        // @phpstan-ignore new.static
         return new static();
     }
 }

--- a/src/Dbal/Type/Boolean.php
+++ b/src/Dbal/Type/Boolean.php
@@ -30,6 +30,7 @@ class Boolean extends Type
 
     public static function factory(Dbal $dbal, array $columnDefinition)
     {
+        // @phpstan-ignore new.static
         return new static($dbal);
     }
 
@@ -37,7 +38,7 @@ class Boolean extends Type
      * Check if $value is valid for this type
      *
      * @param mixed $value
-     * @return boolean|Error
+     * @return bool|Error
      */
     public function validate($value)
     {

--- a/src/Dbal/Type/DateTime.php
+++ b/src/Dbal/Type/DateTime.php
@@ -41,6 +41,7 @@ class DateTime extends Type
 
     public static function factory(Dbal $dbal, array $columnDefinition)
     {
+        // @phpstan-ignore new.static
         return new static(
             $columnDefinition['datetime_precision'],
             strpos($columnDefinition['data_type'], 'time') === false
@@ -51,7 +52,7 @@ class DateTime extends Type
      * Check if $value is valid for this type
      *
      * @param mixed $value
-     * @return boolean|Error
+     * @return bool|Error
      */
     public function validate($value)
     {

--- a/src/Dbal/Type/Enum.php
+++ b/src/Dbal/Type/Enum.php
@@ -35,7 +35,8 @@ class Enum extends Type
         if (!empty($columnDefinition['enumeration_values'])) {
             $allowedValues = explode('\',\'', substr($columnDefinition['enumeration_values'], 1, -1));
         }
-
+        
+        // @phpstan-ignore new.static
         return new static($allowedValues);
     }
 
@@ -43,7 +44,7 @@ class Enum extends Type
      * Check if $value is valid for this type
      *
      * @param mixed $value
-     * @return boolean|Error
+     * @return bool|Error
      */
     public function validate($value)
     {

--- a/src/Dbal/Type/Json.php
+++ b/src/Dbal/Type/Json.php
@@ -19,7 +19,7 @@ class Json extends Type
      * Check if $value is valid for this type
      *
      * @param mixed $value
-     * @return boolean|Error
+     * @return bool|Error
      */
     public function validate($value)
     {

--- a/src/Dbal/Type/Number.php
+++ b/src/Dbal/Type/Number.php
@@ -18,7 +18,7 @@ class Number extends Type
      * Check if $value is valid for this type
      *
      * @param mixed $value
-     * @return boolean|Error
+     * @return bool|Error
      */
     public function validate($value)
     {

--- a/src/Dbal/Type/Set.php
+++ b/src/Dbal/Type/Set.php
@@ -20,7 +20,7 @@ class Set extends Enum
      * Check if $value is valid for this type
      *
      * @param mixed $value
-     * @return boolean|Error
+     * @return bool|Error
      */
     public function validate($value)
     {

--- a/src/Dbal/Type/Time.php
+++ b/src/Dbal/Type/Time.php
@@ -23,7 +23,7 @@ class Time extends DateTime
      * Check if $value is valid for this type
      *
      * @param mixed $value
-     * @return boolean|Error
+     * @return bool|Error
      */
     public function validate($value)
     {

--- a/src/Dbal/Type/VarChar.php
+++ b/src/Dbal/Type/VarChar.php
@@ -36,6 +36,7 @@ class VarChar extends Type
 
     public static function factory(Dbal $dbal, array $columnDefinition)
     {
+        // @phpstan-ignore new.static
         return new static($columnDefinition['character_maximum_length']);
     }
 
@@ -43,7 +44,7 @@ class VarChar extends Type
      * Check if $value is valid for this type
      *
      * @param mixed $value
-     * @return boolean|Error
+     * @return bool|Error
      */
     public function validate($value)
     {

--- a/src/EM.php
+++ b/src/EM.php
@@ -3,4 +3,4 @@
 namespace ORM;
 
 // @codeCoverageIgnoreStart
-class_alias(EntityManager::class, EM::class);
+class_alias(EntityManager::class, 'ORM\EM');

--- a/src/Entity.php
+++ b/src/Entity.php
@@ -88,7 +88,7 @@ abstract class Entity implements Serializable
     protected $exists = false;
 
     /** The entity manager from which this entity got created
-     * @var EM */
+     * @var ?EM */
     protected $entityManager;
 
     /**
@@ -593,7 +593,7 @@ abstract class Entity implements Serializable
      * Set currently related object
      *
      * @param string $relation
-     * @param array|Entity[]|?Entity $related
+     * @param array|Entity[]|Entity|null $related
      * @codeCoverageIgnore trivial code
      * @internal
      */

--- a/src/Entity/Relations.php
+++ b/src/Entity/Relations.php
@@ -149,7 +149,9 @@ trait Relations
     public function fetch($relation, $getAll = false)
     {
         // @codeCoverageIgnoreStart
+        // @phpstan-ignore-next-line booleanAnd.alwaysFalse, instanceof.alwaysFalse, booleanOr.alwaysFalse
         if ($getAll instanceof EM || func_num_args() === 3 && $getAll === null) {
+            // @phpstan-ignore-next-line identical.alwaysTrue
             $getAll = func_num_args() === 3 ? func_get_arg(2) : false;
             trigger_error(
                 'Passing EntityManager to fetch is deprecated. Use ->setEntityManager() to overwrite',
@@ -186,7 +188,7 @@ trait Relations
      * @param string $relation
      * @return bool
      */
-    public function hasLoaded($relation)
+    public function hasLoaded(string $relation): bool
     {
         return array_key_exists($relation, $this->relatedObjects);
     }
@@ -196,9 +198,9 @@ trait Relations
      *
      * Helpful to reduce the size of serializations of the object (for caching, or toArray method etc.)
      *
-     * @param null $relation
+     * @param ?string $relation
      */
-    public function resetRelated($relation = null)
+    public function resetRelated(?string $relation = null): void
     {
         if ($relation === null) {
             $this->relatedObjects = [];

--- a/src/EntityFetcher.php
+++ b/src/EntityFetcher.php
@@ -99,7 +99,7 @@ class EntityFetcher extends QueryBuilder
      *
      * If there is no more entity in the result set it returns null.
      *
-     * @return Entity
+     * @return ?Entity
      */
     public function one()
     {

--- a/src/EntityFetcher/TranslatesClasses.php
+++ b/src/EntityFetcher/TranslatesClasses.php
@@ -75,14 +75,13 @@ trait TranslatesClasses
     /**
      * Get the table name and alias for a class
      *
-     * @param string $class
+     * @param class-string<Entity> $class
      * @param string $alias
      * @return array [$table, $alias]
      */
     protected function getTableAndAlias($class, $alias = '')
     {
         if (class_exists($class)) {
-            /** @var Entity|string $class */
             $table = $this->entityManager->escapeIdentifier($class::getTableName());
             $alias = $alias ?: 't' . count($this->classMapping['byAlias']);
 

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -52,19 +52,19 @@ class EntityManager
     /** @deprecated */
     const OPT_PGSQL_BOOLEAN_FALSE = 'pgsqlFalse';
 
-    /** @var callable */
+    /** @var ?callable */
     protected static $resolver;
 
     /** Connection to database
-     * @var PDO|callable|DbConfig */
+     * @var PDO|callable|DbConfig|null */
     protected $connection;
 
     /** The Database Abstraction Layer
-     * @var Dbal */
+     * @var ?Dbal */
     protected $dbal;
 
     /** The Namer instance
-     * @var Namer */
+     * @var ?Namer */
     protected $namer;
 
     /** The Entity map
@@ -162,7 +162,7 @@ class EntityManager
      * Get the instance by NameSpace mapping
      *
      * @param $class
-     * @return EntityManager
+     * @return ?EntityManager
      */
     private static function getInstanceByNameSpace($class)
     {
@@ -179,7 +179,7 @@ class EntityManager
      * Get the instance by Parent class mapping
      *
      * @param $class
-     * @return EntityManager
+     * @return ?EntityManager
      */
     private static function getInstanceByParent($class)
     {
@@ -698,13 +698,17 @@ class EntityManager
      *
      * @param string $class
      * @param ?ObserverInterface $observer
-     * @return ?CallbackObserver
+     * @return ($observer is null ? CallbackObserver : null)
      * @throws InvalidArgument
      */
     public function observe($class, ?ObserverInterface $observer = null)
     {
-        $returnObserver = !$observer;
-        $observer || $observer = new CallbackObserver();
+        if (!$observer) {
+            $observer = new CallbackObserver();
+            $returnObserver = true;
+        } else {
+            $returnObserver = false;
+        }
 
         if (!isset($this->observers[$class])) {
             $this->observers[$class] = [];
@@ -739,7 +743,12 @@ class EntityManager
             $this->observers[$class] = array_filter(
                 $observers,
                 function (ObserverInterface $current) use ($observer, &$removed) {
-                    return $current === $observer ? !($removed = true) : true;
+                    if ($current === $observer) {
+                        $removed = true;
+                        return false;
+                    }
+                    
+                    return true;
                 }
             );
         }

--- a/src/EntityManager.php
+++ b/src/EntityManager.php
@@ -697,17 +697,16 @@ class EntityManager
      * For more information about model events please consult the [documentation](https://tflori.github.io/
      *
      * @param string $class
-     * @param ?ObserverInterface $observer
-     * @return ($observer is null ? CallbackObserver : null)
+     * @param ?ObserverInterface $_observer
+     * @return ($_observer is null ? CallbackObserver : null)
      * @throws InvalidArgument
      */
-    public function observe($class, ?ObserverInterface $observer = null)
+    public function observe($class, ?ObserverInterface $_observer = null)
     {
-        if (!$observer) {
+        if (!$_observer) {
             $observer = new CallbackObserver();
-            $returnObserver = true;
         } else {
-            $returnObserver = false;
+            $observer = $_observer;
         }
 
         if (!isset($this->observers[$class])) {
@@ -717,7 +716,8 @@ class EntityManager
         }
 
         $this->observers[$class][] = $observer;
-        return $returnObserver ? $observer : null;
+        // @phpstan-ignore-next-line instanceof.alwaysTrue
+        return !$_observer && $observer instanceof CallbackObserver ? $observer : null;
     }
 
     /**

--- a/src/MockTrait.php
+++ b/src/MockTrait.php
@@ -10,7 +10,7 @@ use ORM\Testing\MocksEntityManager;
  * @package ORM
  * @see     MocksEntityManager
  */
-trait MockTrait
+trait MockTrait // @phpstan-ignore trait.unused
 {
     use MocksEntityManager;
 }

--- a/src/Namer.php
+++ b/src/Namer.php
@@ -189,7 +189,7 @@ class Namer
         }
 
         if ($prefix !== null) {
-            $name = preg_replace('~^' . preg_quote($prefix) . '~', '', $name);
+            $name = preg_replace('~^' . preg_quote($prefix, '~') . '~', '', $name);
         }
 
         return $this->forceNamingScheme($name, $namingScheme);
@@ -294,7 +294,7 @@ class Namer
     protected function getValue($attribute, $values, $arrayGlue)
     {
         $placeholder = '%' . $attribute . '%';
-        if (preg_match('/\[(-?\d+\*?)\]$/', $attribute, $arrayAccessor)) {
+        if (preg_match('/\[(-?\d+\*?)]$/', $attribute, $arrayAccessor)) {
             $attribute     = substr($attribute, 0, strpos($attribute, '['));
             $arrayAccessor = $arrayAccessor[1];
         } else {

--- a/src/QueryBuilder/ExecutesQueries.php
+++ b/src/QueryBuilder/ExecutesQueries.php
@@ -10,7 +10,7 @@ use PDOStatement;
  *
  * Hold all methods required from the query builder to execute queries.
  *
- * @property EntityManager $entityManager
+ * @property ?EntityManager $entityManager
  */
 trait ExecutesQueries
 {

--- a/src/QueryBuilder/MakesJoins.php
+++ b/src/QueryBuilder/MakesJoins.php
@@ -19,7 +19,6 @@ trait MakesJoins
      */
     protected function createJoin($joinClause, $expression = '', $args = [])
     {
-        /** @var QueryBuilder $this */
         $empty = is_bool($expression) ? $expression : false;
         $expression = is_string($expression) ? $expression : '';
 

--- a/src/QueryBuilder/ParenthesisInterface.php
+++ b/src/QueryBuilder/ParenthesisInterface.php
@@ -157,21 +157,21 @@ interface ParenthesisInterface
      * Alias for andParenthesis
      *
      * @see ParenthesisInterface::andWhere()
-     * @return $this
+     * @return ParenthesisInterface
      */
     public function parenthesis();
 
     /**
      * Add a parenthesis with AND
      *
-     * @return $this
+     * @return ParenthesisInterface
      */
     public function andParenthesis();
 
     /**
      * Add a parenthesis with OR
      *
-     * @return $this
+     * @return ParenthesisInterface
      */
     public function orParenthesis();
 
@@ -198,7 +198,7 @@ interface ParenthesisInterface
      *
      * @param string $column   Column or expression with placeholders
      * @param string $operator Operator, value or array of values
-     * @param string $value    Value (required when used with operator)
+     * @param mixed $value    Value (required when used with operator)
      * @return string
      * @internal
      */

--- a/src/QueryBuilder/QueryBuilder.php
+++ b/src/QueryBuilder/QueryBuilder.php
@@ -61,7 +61,7 @@ class QueryBuilder extends Parenthesis implements QueryBuilderInterface
     protected $modifier = [];
 
     /** EntityManager to use for quoting
-     * @var EntityManager */
+     * @var ?EntityManager */
     protected $entityManager;
 
     /** The default EntityManager to use to for quoting
@@ -147,7 +147,7 @@ class QueryBuilder extends Parenthesis implements QueryBuilderInterface
             $operator = $operator ?: $this->getDefaultOperator($value);
 
             if (in_array(strtoupper($operator), [ 'IN', 'NOT IN' ])) {
-                return $this->buildWhereInExpression($column, $value, strtoupper($operator) === 'NOT IN');
+                return $this->buildWhereInExpression($column, (array)$value, strtoupper($operator) === 'NOT IN');
             }
 
             $expression = $column . ' ' . $operator . ' ?';

--- a/src/Relation/ManyToMany.php
+++ b/src/Relation/ManyToMany.php
@@ -113,8 +113,9 @@ class ManyToMany extends Relation
 
         $attributes = array_keys($this->reference);
         $fkColumns = array_values($this->reference);
-        $opFkColumns = array_values($opponent->reference);
-        $opAttributes = array_keys($opponent->reference);
+        $reference = $opponent->getReference();
+        $opFkColumns = array_values($reference);
+        $opAttributes = array_keys($reference);
 
         $mappingData = $this->getMappingData($em, ...$entities);
 

--- a/src/Relation/ManyToMany.php
+++ b/src/Relation/ManyToMany.php
@@ -293,7 +293,7 @@ class ManyToMany extends Relation
 
     /**
      * @param EntityManager $em
-     * @param Entity[] $entities
+     * @param Entity ...$entities
      * @return array
      */
     protected function getMappingData(EntityManager $em, Entity ...$entities)

--- a/src/Relation/OneToMany.php
+++ b/src/Relation/OneToMany.php
@@ -71,6 +71,7 @@ class OneToMany extends Relation
         }
 
         if (count($short) === 2 && is_string($short[0]) && is_string($short[1])) {
+            // @phpstan-ignore-next-line new.static
             return new static($short[0], $short[1], $filters);
         }
         return null;
@@ -89,6 +90,7 @@ class OneToMany extends Relation
         $filters = isset($relDef[self::OPT_FILTERS]) ? $relDef[self::OPT_FILTERS] : [];
 
         if ($class && $opponent && !isset($relDef['table'])) {
+            // @phpstan-ignore-next-line new.static
             return new static($class, $opponent, $filters);
         }
         return null;

--- a/src/Testing/EntityFetcherMock/Result.php
+++ b/src/Testing/EntityFetcherMock/Result.php
@@ -87,7 +87,7 @@ class Result extends EntityFetcher
     /**
      * Add entities to the result
      *
-     * @param Entity[] $entities
+     * @param Entity ...$entities
      * @return $this
      * @codeCoverageIgnore trivial code
      */

--- a/src/Testing/EntityFetcherMock/ResultRepository.php
+++ b/src/Testing/EntityFetcherMock/ResultRepository.php
@@ -140,7 +140,7 @@ class ResultRepository
             return [];
         }
 
-        arsort($results, SORT_DESC);
+        arsort($results);
         $objHash = array_keys($results)[0];
         return $this->results[$class][$objHash]->getEntities();
     }

--- a/src/Testing/MocksEntityManager.php
+++ b/src/Testing/MocksEntityManager.php
@@ -274,6 +274,7 @@ trait MocksEntityManager
     {
         $expectation = $entity->shouldReceive('save');
 
+        // @phpstan-ignore-next-line instanceof.alwaysFalse
         if ($expectation instanceof m\CompositeExpectation) {
             $expectation->andReturnUsing(
                 function () use ($entity, $updatedData, $changingData) {

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ORM\Testing;
+
+class TestCase extends \PHPUnit\Framework\TestCase
+{
+    use MocksEntityManager;
+}

--- a/tests/Dbal/ValidateTest.php
+++ b/tests/Dbal/ValidateTest.php
@@ -153,6 +153,6 @@ class ValidateTest extends TestCase
         $result = $this->column->validate('y');
 
         self::assertInstanceOf(\ORM\Dbal\Error\NotValid::class, $result);
-        self::assertSame('UNKNOWN', $result->getPrevious()->getCode());
+        self::assertSame('UNKNOWN', $result->getError()->getErrorCode());
     }
 }


### PR DESCRIPTION
Add PHPStan static analysis as a separate CI step before running tests. Also suppress new.static warnings in Type subclasses and update boolean return type hints from `boolean` to `bool` in phpdoc blocks.